### PR TITLE
Work In Progress

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/constants/BatchEngineImportTaskConstants.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/constants/BatchEngineImportTaskConstants.java
@@ -19,6 +19,15 @@ package com.liferay.batch.engine.constants;
  */
 public class BatchEngineImportTaskConstants {
 
+	public static final String BATCH_ENGINE =
+		"com_liferay_batch_engine_web_internal_portlet_BatchEnginePortlet";
+
+	public static final String BATCH_ENGINE_ADMIN_IMPORT =
+		"com_liferay_batch_engine_web_internal_portlet_BatchEngineAdmin" +
+			"Portlet";
+
+	public static final int BATCH_IMPORT_COMPLETION = 42;
+
 	public static final int IMPORT_STRATEGY_ON_ERROR_CONTINUE = 1;
 
 	public static final int IMPORT_STRATEGY_ON_ERROR_FAIL = 2;
@@ -28,5 +37,8 @@ public class BatchEngineImportTaskConstants {
 
 	public static final String IMPORT_STRATEGY_STRING_ON_ERROR_FAIL =
 		"ON_ERROR_FAIL";
+
+	public static final String BATCH_RESOURCE_NAME =
+		"com.liferay.batch.engine";
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/notifications/BatchEngineImportNotificationEventSender.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/notifications/BatchEngineImportNotificationEventSender.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.internal.notifications;
+
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+//import com.liferay.batch.engine.web.internal.portlet.BatchEngineAdminPortlet;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.settings.LocalizedValuesMap;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupSubscriptionCheckSubscriptionSender;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SubscriptionSender;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.sql.Blob;
+import java.util.Locale;
+
+/**
+ * class BatchPlannerImportNotificationEventSender: This is the admin login notification
+ * sender that implements the import completion event sender.
+ *
+ * @author Joe Duffy
+ */
+public class BatchEngineImportNotificationEventSender {
+
+	public static void notifySubscribers(
+		BatchEngineImportTask batchEngineImportTask, String fromHost,
+		ServiceContext serviceContext)
+		throws PortalException {
+
+		long userId = batchEngineImportTask.getUserId();
+		long companyId = batchEngineImportTask.getCompanyId();
+
+		String entryTitle = "Batch Import Completion";
+
+		String entryURL = "http://localhost:8080/group/guest/~/control_panel/" +
+						  "manage?p_p_id=com_liferay_batch_planner_web_intern" +
+						  "al_portlet_BatchPlannerPortlet&p_p_lifecycle=0&p_p" +
+						  "_state=maximized&p_v_l_s_g_id=38321&p_p_auth=" +
+						  "JmrCRq2Y";
+
+		if (Validator.isNull(entryURL)) {
+			entryURL = StringBundler.concat(
+				serviceContext.getLayoutFullURL(),
+				Portal.FRIENDLY_URL_SEPARATOR, "batch-engine/",
+				batchEngineImportTask.getClassName());
+
+			// alternative: getBatchEngineImportTaskID.toString
+
+		}
+
+		String fromName = "";
+		String fromAddress = "";
+
+		LocalizedValuesMap subjectLocalizedValuesMap = new LocalizedValuesMap();
+		LocalizedValuesMap bodyLocalizedValuesMap = new LocalizedValuesMap();
+
+		subjectLocalizedValuesMap.put(
+			LocaleUtil.ENGLISH, "Batch Import Completion");
+		bodyLocalizedValuesMap.put(
+			LocaleUtil.ENGLISH, "Batch Import Has Completed.");
+
+		SubscriptionSender subscriptionSender = new SubscriptionSender();
+//			new GroupSubscriptionCheckSubscriptionSender(BatchEngineImportTaskConstants.BATCH_RESOURCE_NAME);
+
+		subscriptionSender.setClassPK(batchEngineImportTask.getBatchEngineImportTaskId());
+		subscriptionSender.setClassName(
+			"com.liferay.batch.engine.web." +
+			"internal.portlet.BatchEngineAdminPortlet");
+//			BatchEngineAdminPortlet.class.getName());
+
+		subscriptionSender.setCompanyId(companyId);
+	/*	Blob blob = batchEngineImportTask.getContent();
+		if (blob != null) {
+			byte[] bdata = blob.getBytes(1, (int) blob.length());
+		}*/
+		subscriptionSender.setContextAttribute(
+			"[$BATCH_IMPORT_CONTENT$]",
+			"Details of import task",
+			false);
+
+		String description = "Import task status";
+
+		if (Validator.isNotNull(description)) {
+			subscriptionSender.setContextAttribute(
+				"[$BATCH_IMPORT_DESCRIPTION$]", description, false);
+		}
+		else {
+			subscriptionSender.setContextAttribute(
+				"[$BATCH_IMPORT_DESCRIPTION$]",
+				"More description...",
+//				StringUtil.shorten(HtmlUtil.stripHtml(entry.getContent()), 400),
+				false);
+		}
+
+		subscriptionSender.setContextAttributes(
+			"[$BATCH_IMPORT_CREATE_DATE$]",
+			Time.getSimpleDate(batchEngineImportTask.getModifiedDate(), "yyyy/MM/dd"),
+			"[$BATCH_IMPORT_STATUS_BY_USER_NAME$]", 0,
+			"[$BATCH_IMPORT_TITLE$]", "Completion Status",
+			"[$BATCH_IMPORT_UPDATE_COMMENT$]", "<done>",
+//			HtmlUtil.replaceNewLine(
+//				GetterUtil.getString(
+//					serviceContext.getAttribute("emailEntryUpdatedComment"))),
+			"[$BATCH_IMPORT_URL$]", "localhost:8080",
+			"[$BATCH_IMPORT_USER_PORTRAIT_URL$]", "localhost:8080",
+//			workflowContext.get(WorkflowConstants.CONTEXT_USER_PORTRAIT_URL),
+			"[$BATCH_IMPORT_USER_URL$]", "localhost:8080"
+//			workflowContext.get(WorkflowConstants.CONTEXT_USER_URL)
+			);
+		subscriptionSender.setContextCreatorUserPrefix("BATCH_IMPORT");
+		subscriptionSender.setCreatorUserId(userId);
+		subscriptionSender.setCurrentUserId(userId);
+		subscriptionSender.setEntryTitle(entryTitle);
+		subscriptionSender.setEntryURL(entryURL);
+		subscriptionSender.setFrom(fromAddress, fromName);
+		subscriptionSender.setHtmlFormat(true);
+
+		subscriptionSender.setMailId(null, 0);
+
+		int notificationType =
+			BatchEngineImportTaskConstants.BATCH_IMPORT_COMPLETION;
+
+		subscriptionSender.setNotificationType(notificationType);
+
+		String portletId =
+			BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT;
+
+		subscriptionSender.setPortletId(portletId);
+
+		subscriptionSender.setReplyToAddress(fromAddress);
+		subscriptionSender.setServiceContext(serviceContext);
+
+		subscriptionSender.setGroupId(serviceContext.getScopeGroupId());
+		subscriptionSender.addPersistedSubscribers(
+			"com.liferay.batch.engine.web.internal.portlet." +
+			"BatchEngineAdminPortlet", batchEngineImportTask.getBatchEngineImportTaskId());
+//			BatchEngineAdminPortlet.class.getName(), 0);
+
+		subscriptionSender.flushNotificationsAsync();
+	}
+
+}

--- a/modules/apps/batch-engine/batch-engine-web/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-web/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Batch Engine Web
+Bundle-SymbolicName: com.liferay.batch.engine.web
+Bundle-Version: 1.0.0

--- a/modules/apps/batch-engine/batch-engine-web/build.gradle
+++ b/modules/apps/batch-engine/batch-engine-web/build.gradle
@@ -2,21 +2,17 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
-	compileOnly group: "jstl", name: "jstl", version: "1.2"
+	compileOnly group: "org.apache.commons", name: "commons-compress", version: "1.21"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.annotation", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.jaxrs", version: "1.0.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
-	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:batch-engine:batch-engine-api")
-	compileOnly project(":apps:batch-planner:batch-planner-api")
-	compileOnly project(":apps:frontend-taglib:frontend-taglib")
-	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
-	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
-	compileOnly project(":apps:petra:petra-portlet-url-builder")
-	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-memory")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/notifications/BatchEngineImportUserNotificationDefinition.java
+++ b/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/notifications/BatchEngineImportUserNotificationDefinition.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.web.internal.notifications;
+
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
+import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
+import com.liferay.portal.kernel.notifications.UserNotificationDeliveryType;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Joe Duffy
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT,
+	service = UserNotificationDefinition.class
+)
+public class BatchEngineImportUserNotificationDefinition
+	extends UserNotificationDefinition {
+
+	public BatchEngineImportUserNotificationDefinition() {
+		super(
+			BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT, 0,
+			UserNotificationDefinition.NOTIFICATION_TYPE_ADD_ENTRY,
+			"receive-a-notification-when-import-task-completes");
+
+		// add receive-a-notification-when-batch-import-completes to lang
+		// and replace key here
+
+		addUserNotificationDeliveryType(
+			new UserNotificationDeliveryType(
+				"website", UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+				true));
+	}
+
+}

--- a/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/notifications/BatchEngineImportUserNotificationHandler.java
+++ b/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/notifications/BatchEngineImportUserNotificationHandler.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.web.internal.notifications;
+
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
+import com.liferay.portal.kernel.notifications.BaseUserNotificationHandler;
+import com.liferay.portal.kernel.notifications.UserNotificationHandler;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Joe Duffy
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT,
+	service = UserNotificationHandler.class
+)
+public class BatchEngineImportUserNotificationHandler
+	extends BaseUserNotificationHandler {
+
+	/**
+	 * AdminLoginUserNotificationHandler: Constructor class.
+	 */
+	public BatchEngineImportUserNotificationHandler() {
+		setPortletId(BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT);
+	}
+
+	@Override
+	protected String getBody(
+			UserNotificationEvent userNotificationEvent,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		String userName = LanguageUtil.get(
+			serviceContext.getLocale(), _UKNOWN_USER_KEY);
+
+		// okay, we need to get the user for the event
+
+		User user = _userLocalService.fetchUser(
+			userNotificationEvent.getUserId());
+
+		if (user != null) {
+
+			// get the company the user belongs to.
+
+			Company company = _companyLocalService.fetchCompany(
+				user.getCompanyId());
+
+			// based on the company auth type, find the user name to display.
+			// so we'll get screen name or email address or whatever they're
+			// using to log in.
+
+			String authType = company.getAuthType();
+
+			if (company != null) {
+				if (authType.equals(CompanyConstants.AUTH_TYPE_EA)) {
+					userName = user.getEmailAddress();
+				}
+				else if (authType.equals(CompanyConstants.AUTH_TYPE_SN)) {
+					userName = user.getScreenName();
+				}
+				else if (authType.equals(CompanyConstants.AUTH_TYPE_ID)) {
+					userName = String.valueOf(user.getUserId());
+				}
+			}
+		}
+
+		// we'll be stashing the client address in the payload of the event,
+		// so let's extract it here.
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			userNotificationEvent.getPayload());
+
+		//      String fromHost = jsonObject.getString(Constants.FROM_HOST);
+
+		String fromHost = jsonObject.getString("fromHost");
+
+		// fetch our strings via the language bundle.
+
+		String title = LanguageUtil.get(serviceContext.getLocale(), _TITLE_KEY);
+
+		String body = LanguageUtil.format(
+			serviceContext.getLocale(), _BODY_KEY,
+			new Object[] {userName, fromHost});
+
+		// build the html using our template.
+
+		return StringUtil.replace(
+			_BODY_TEMPLATE, _BODY_REPLACEMENTS, new String[] {title, body});
+	}
+
+	@Reference(unbind = "-")
+	protected void setCompanyLocalService(
+		CompanyLocalService companyLocalService) {
+
+		_companyLocalService = companyLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setUserLocalService(UserLocalService userLocalService) {
+		_userLocalService = userLocalService;
+	}
+
+	private static final String _BODY_KEY = "body.batch.engine";
+
+	private static final String[] _BODY_REPLACEMENTS = {
+		"[$TITLE$]", "[$BODY$]"
+	};
+
+	private static final String _BODY_TEMPLATE =
+		"<div class=\"title\">[$TITLE$]</div><div class=\"body\">[$BODY$]</div>";
+
+	private static final String _TITLE_KEY = "title.batch.engine";
+
+	private static final String _UKNOWN_USER_KEY = "unknown.user";
+
+	private CompanyLocalService _companyLocalService;
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/portlet/BatchEngineAdminPortlet.java
+++ b/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/portlet/BatchEngineAdminPortlet.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.web.internal.portlet;
+
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.SubscriptionLocalService;
+
+import java.io.IOException;
+
+import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.instanceable=true",
+		"javax.portlet.display-name=import-export",
+		"javax.portlet.name=" + BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT,
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user"
+	},
+	service = Portlet.class
+)
+public class BatchEngineAdminPortlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		// pass in the service.
+
+		renderRequest.setAttribute(
+			"subscriptionLocalService", _subscriptionLocalService);
+
+		super.render(renderRequest, renderResponse);
+	}
+
+	@Reference(unbind = "-")
+	protected void setSubscriptionLocalService(
+		SubscriptionLocalService subscriptionLocalService) {
+
+		_subscriptionLocalService = subscriptionLocalService;
+	}
+
+	private SubscriptionLocalService _subscriptionLocalService;
+
+}

--- a/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/portlet/action/SubscribeImportNotificationMVCActionCommand.java
+++ b/modules/apps/batch-engine/batch-engine-web/src/main/java/com/liferay/batch/engine/web/internal/portlet/action/SubscribeImportNotificationMVCActionCommand.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.web.internal.portlet.action;
+
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.web.internal.portlet.BatchEngineAdminPortlet;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.SubscriptionLocalService;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * class SubscribeMVCActionCommand: The action command to handle subscription and unsubscription.
+ *
+ * @author Joe Duffy
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + BatchEngineImportTaskConstants.BATCH_ENGINE_ADMIN_IMPORT,
+		"mvc.command.name=/update_subscription/update"
+	},
+	service = MVCActionCommand.class
+)
+public class SubscribeImportNotificationMVCActionCommand
+	extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
+
+		long userId = PortalUtil.getUserId(actionRequest);
+
+		if (Constants.SUBSCRIBE.equals(cmd)) {
+			_subscriptionLocalService.addSubscription(
+				userId, 0, BatchEngineAdminPortlet.class.getName(), 0);
+		}
+		else if (Constants.UNSUBSCRIBE.equals(cmd)) {
+			_subscriptionLocalService.deleteSubscription(
+				userId, BatchEngineAdminPortlet.class.getName(), 0);
+		}
+	}
+
+	@Reference(unbind = "-")
+	protected void setSubscriptionLocalService(
+		SubscriptionLocalService subscriptionLocalService) {
+
+		_subscriptionLocalService = subscriptionLocalService;
+	}
+
+	private SubscriptionLocalService _subscriptionLocalService;
+
+}

--- a/modules/apps/batch-engine/batch-engine-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/batch-engine/batch-engine-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,22 @@
+<%@ page import="com.liferay.portal.kernel.service.SubscriptionLocalService" %>
+<%@ page import="com.liferay.portal.kernel.model.Subscription" %>
+<%@ page import="com.liferay.batch.engine.web.internal.portlet.BatchEngineAdminPortlet" %>
+<%@ page import="com.liferay.portal.kernel.exception.PortalException" %>
+<%@ page import="com.liferay.portal.kernel.util.Constants" %>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
+<%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
+<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />
+
+<%
+	SubscriptionLocalService subscriptionLocalService = (SubscriptionLocalService) renderRequest.getAttribute("subscriptionLocalService");
+%>

--- a/modules/apps/batch-engine/batch-engine-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/batch-engine/batch-engine-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,32 @@
+<%@ include file="/init.jsp" %>
+
+<%
+	Subscription subscription = subscriptionLocalService.fetchSubscription(user.getCompanyId(), user.getUserId(), BatchEngineAdminPortlet.class.getName(), 0);
+
+	boolean subscribed = false;
+	String command = Constants.SUBSCRIBE;
+
+	if (subscription != null) {
+		subscribed = true;
+		command = Constants.UNSUBSCRIBE;
+	}
+%>
+<portlet:actionURL name="/update_subscription" var="updateSubscriptionURL">
+	<portlet:param name="mvcActionCommand" value="/update_subscription" />
+</portlet:actionURL>
+
+<h2>Admin Login Notification Subscription</h2>
+<p>Toggle your subscription status.</p>
+
+<aui:form action="<%= updateSubscriptionURL %>" method="post" name="fm" >
+	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= command %>" />
+
+	<aui:fieldset-group markupView="lexicon">
+		<aui:fieldset>
+			<aui:button-row>
+				<aui:button type="submit" value="<%= command %>" />
+			</aui:button-row>
+		</aui:fieldset>
+	</aui:fieldset-group>
+</aui:form>
+

--- a/modules/apps/batch-planner/batch-planner-api/bnd.bnd
+++ b/modules/apps/batch-planner/batch-planner-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Planner API
 Bundle-SymbolicName: com.liferay.batch.planner.api
-Bundle-Version: 7.0.1
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.batch.planner.batch.engine.broker,\
 	com.liferay.batch.planner.configuration,\

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -12025,6 +12025,7 @@ recaptcha-public-key=reCAPTCHA Public Key
 recaptcha-script-url=reCAPTCHA Script URL
 recaptcha-verify-url=reCAPTCHA Verify URL
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed has expired.
+receive-a-notification-when-import-task-completes=owns a batch import task that completes.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-someone=Receive a notification when someone:
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to.


### PR DESCRIPTION
Igor, I've populated ServiceContext and SubscriptionSender (obviously not enough to please the service!) I know portlet keys should be in portlet key class, but when I've had to hard-code URLs (in BatchEngineImportTaskExecutorImpl.java) this is the least of my problems to fix. I could not find a way to get these (URLs) from BatchImportTask - extending this did not seem a good option. 

The existing code was raising an exception in MessageListner - complaining about destination, message body was missing many fields I had sent in subscription sender. I would add log message here, only since my ant-all this morning, I'm just getting an error when I select  "Entity Name" -> "Account".  

Maybe you can take a look to see if any good advice comes to mind?